### PR TITLE
Add support for  a ledger wallet

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 
 [dependencies]
 thiserror = "1.0.38"
-ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, rev = 'ee5e3e52', features = ["abigen"]  }
+ethers = { git = "https://github.com/gakonst/ethers-rs", default-features = false, rev = 'ee5e3e52', features = ["abigen", "ledger"]  }
 tokio = { version = "1.17.0", features = ["macros"] }
 serde_json = "1.0.91"
 serde = "1.0.152"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,8 @@ use async_recursion::async_recursion;
 use blake2::digest::{Update, VariableOutput};
 use blake2::Blake2bVar;
 use ethers::core::k256::ecdsa::SigningKey;
-use ethers::prelude::{HDPath, Ledger};
+use ethers::prelude::HDPath::LedgerLive;
+use ethers::prelude::Ledger;
 use ethers::signers::Signer;
 use ethers::signers::{coins_bip39::English, MnemonicBuilder};
 use ethers::types::transaction::eip2718::TypedTransaction;
@@ -52,7 +53,6 @@ use std::fs;
 use std::sync::Arc;
 
 const DEFAULT_DERIVATION_PATH_PREFIX: &str = "m/44'/60'/0'/0/";
-const DEFAULT_LEDGER_FIL_DERIVATION_PATH: &str = "44'/461'/0'/0/0";
 
 const GAS_LIMIT_MULTIPLIER: i32 = 130;
 // The hash length used for calculating address checksums.
@@ -268,11 +268,10 @@ pub async fn get_ledger_signing_provider(
     provider: Provider<Http>,
     chain_id: u64,
 ) -> Result<SignerMiddleware<Arc<Provider<Http>>, Ledger>, Box<dyn Error>> {
-    let ledger = Ledger::new(
-        HDPath::Other(DEFAULT_LEDGER_FIL_DERIVATION_PATH.to_string()),
-        chain_id,
-    )
-    .await?;
+    // Note: Support for signing transactions using the Ledger Filecoin app still hasn't landed yet and is WIP.
+    // So, the workaround for now is to use the Ethereum Ledger App for signing Filecoin transactions
+    // after funding the corresponding "Ethereum account" on the Filecoin mainnet with funds.
+    let ledger = Ledger::new(LedgerLive(0), chain_id).await?;
     let provider = Arc::new(provider);
 
     Ok(SignerMiddleware::new(provider, ledger))

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
 use std::{fs::read_to_string, path::PathBuf, str::FromStr};
 
 use ethers::types::{Address, Eip1559TransactionRequest};
-use fevm_utils::{filecoin_to_eth_address, get_signing_provider, send_tx};
+use fevm_utils::{filecoin_to_eth_address, get_provider, get_wallet_signing_provider, send_tx};
 
 #[tokio::main]
 pub async fn main() {
@@ -11,8 +11,12 @@ pub async fn main() {
     // rpc for hyperspace testnet
     let rpc_url = "https://api.hyperspace.node.glif.io/rpc/v1";
 
+    let provider = get_provider(rpc_url).unwrap();
+
     let mnemonic = read_to_string(secret).unwrap();
-    let client = get_signing_provider(&mnemonic, rpc_url).await.unwrap();
+    let client = get_wallet_signing_provider(provider, &mnemonic)
+        .await
+        .unwrap();
 
     // recipient to send fil to
     let addr = "t410fkkld55ioe7qg24wvt7fu6pbknb56ht7pt4zamxa";

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,32 +1,66 @@
-use std::{fs::read_to_string, path::PathBuf, str::FromStr};
+use std::sync::Arc;
+use std::{env, fs::read_to_string, path::PathBuf, str::FromStr};
 
 use fevm_utils::{
-    filecoin_to_eth_address, get_provider, get_wallet_signing_provider, send_tx, set_tx_gas,
+    filecoin_to_eth_address, get_ledger_signing_provider, get_provider,
+    get_wallet_signing_provider, send_tx, set_tx_gas,
 };
 
 use ethers::{
     providers::Middleware,
     types::{transaction::eip2718::TypedTransaction, Address, Eip1559TransactionRequest},
 };
-
+// Use -ledger for Ledger mode which will use Filecoin mainnet.
 #[tokio::main]
 pub async fn main() {
     colog::init();
+    let args: Vec<String> = env::args().collect();
+    let mut ledger_mode = false;
+    if args.len() > 1 {
+        println!("{}", args[1]);
+        if args[1] == "-ledger" {
+            ledger_mode = true;
+        }
+    }
 
-    let secret = PathBuf::from("./secrets/secret");
-    // rpc for hyperspace testnet
-    let rpc_url = "https://api.hyperspace.node.glif.io/rpc/v1";
+    if !ledger_mode {
+        println!("Using wallet mode on Hyperspace");
+        let rpc_url = "https://api.hyperspace.node.glif.io/rpc/v1";
+        let provider = get_provider(rpc_url).unwrap();
+        let secret = PathBuf::from("./secrets/secret");
+        let mnemonic = read_to_string(secret).unwrap();
+        let client = get_wallet_signing_provider(provider, &mnemonic)
+            .await
+            .unwrap();
+        let client = Arc::new(client);
+        send_funds(
+            client.clone(),
+            client.address(),
+            "t410fkkld55ioe7qg24wvt7fu6pbknb56ht7pt4zamxa",
+        )
+        .await;
+    } else {
+        println!("Using ledger mode on Filecoin mainnet");
+        // Only mainnet supported for Ledger for now
+        let rpc_url = "https://api.node.glif.io/rpc/v1";
+        let provider = get_provider(rpc_url).unwrap();
+        let chain_id = provider.get_chainid().await.unwrap();
+        let client = get_ledger_signing_provider(provider, chain_id.as_u64())
+            .await
+            .unwrap();
 
-    let provider = get_provider(rpc_url).unwrap();
+        let client = Arc::new(client);
+        send_funds(
+            Arc::new(client.clone()),
+            client.address(),
+            "f410fkkld55ioe7qg24wvt7fu6pbknb56ht7pt4zamxa",
+        )
+        .await;
+    }
+}
 
-    let mnemonic = read_to_string(secret).unwrap();
-    let client = get_wallet_signing_provider(provider, &mnemonic)
-        .await
-        .unwrap();
-
-    // recipient to send fil to
-    let addr = "t410fkkld55ioe7qg24wvt7fu6pbknb56ht7pt4zamxa";
-    let eth_addr = filecoin_to_eth_address(addr, "").await.unwrap();
+async fn send_funds<S: Middleware + 'static>(client: Arc<S>, from: Address, to: &str) {
+    let eth_addr = filecoin_to_eth_address(to, "").await.unwrap();
 
     assert_eq!(eth_addr, "0x52963ef50e27e06d72d59fcb4f3c2a687be3cfef");
 
@@ -34,7 +68,7 @@ pub async fn main() {
     let mut fund_tx: TypedTransaction = Eip1559TransactionRequest::new()
         .to(Address::from_str(&eth_addr).unwrap())
         .value(1)
-        .from(client.address())
+        .from(from)
         .into(); // specify the `from` field so that the client knows which account to use
 
     let gas_price = client.provider().get_gas_price().await.unwrap();


### PR DESCRIPTION
Uses the default Filecoin derivation path and assumes user has only one FIL account.