### PR TITLE
chore: cleanup executor and contract interfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,21 +168,25 @@ To test the contract locally:
 
 const WASM_COMPILED_PATH: &str = "./build/tests/HelloWorld.bin";
 const ABI_PATH: &str = "./build/tests/HelloWorld.abi";
+use fevm_utils::executor::TestExecutor;
 
-use fevm_utils::executor::{Contract, TestExecutor};
-
-
+#[test]
 pub fn main() {
-     // create a local executor
-     let mut test_executor = TestExecutor::new().unwrap();
+    // create a local executor
+    let mut test_executor = TestExecutor::new().unwrap();
 
     // deploy hellow world using test address 0
-     let mut contract =
-            Contract::deploy(&mut test_executor, 0, WASM_COMPILED_PATH, ABI_PATH).unwrap();
-    
-    // call helloworld using test address 0
-     contract.call_fn(&mut test_executor, 0, "sayHelloWorld", &[]).unwrap();
+    let mut contract = test_executor.deploy(WASM_COMPILED_PATH, ABI_PATH).unwrap();
 
+    // call helloworld using test address 0
+    test_executor
+        .call_fn(&mut contract, "sayHelloWorld", &[])
+        .unwrap();
+
+    // print gas usage
+    let table = contract.create_gas_table();
+
+    table.print_tty(true).unwrap();
 }
 
 ```

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -118,17 +118,16 @@ impl TestExecutor {
     /// Sends funds from an account to an address
     pub fn send_funds(
         &mut self,
-        from: Account,
         to: Address,
         value: TokenAmount,
     ) -> Result<ApplyRet, Box<dyn Error>> {
         let sequence = self
             .sequence
-            .get_mut(&from)
+            .get_mut(&self.accounts[self.sender])
             .ok_or_else(|| ExecutorError::UninitializedSequence)?;
 
         let message = Message {
-            from: from.1,
+            from: self.accounts[self.sender].1,
             to,
             gas_limit: 1000000000,
             value,
@@ -556,12 +555,9 @@ mod sendtests {
         let balance = test_executor.get_balance(actor_id).unwrap();
         assert_eq!(balance, TokenAmount::from_atto(10000));
 
+        // send from the currently active account i.e `sender` on the TestExecutor
         let send_res = test_executor
-            .send_funds(
-                test_executor.accounts[0],
-                contract.address,
-                TokenAmount::from_atto(10000),
-            )
+            .send_funds(contract.address, TokenAmount::from_atto(10000))
             .unwrap();
         assert_eq!(send_res.msg_receipt.exit_code.value(), 0);
 


### PR DESCRIPTION
- Creates a default sender for a given executor (which can be updated). 

- `deploy` and `call_fn` are `TestExecutor` methods to reduce repeated arguments across calls 

- Introduce helper methods for deserializing return bytes into Ethereum types / (`Token` type). 

For instance: 

```rust 
 // we know from the abi that it returns an int so we decode accordingly
        assert_eq!(
            call.decode_return_data(&vec![ParamType::Uint(256)])
                .unwrap()[0]
                .clone(),
            Token::Uint(U256::from(100))
        );

```

The HelloWorld example is illustrative of the simplifications these changes induce: 

```rust
    const WASM_COMPILED_PATH: &str = "./build/tests/HelloWorld.bin";
    const ABI_PATH: &str = "./build/tests/HelloWorld.abi";
    use fevm_utils::executor::TestExecutor;

    #[test]
    pub fn main() {
        // create a local executor
        let mut test_executor = TestExecutor::new().unwrap();

        // deploy hellow world using test address 0
        let mut contract = test_executor.deploy(WASM_COMPILED_PATH, ABI_PATH).unwrap();

        // call helloworld using test address 0
        test_executor
            .call_fn(&mut contract, "sayHelloWorld", &[])
            .unwrap();

        // print gas usage
        let table = contract.create_gas_table();

        table.print_tty(true).unwrap();
    }


```