### PR TITLE
fix: cbor headers 

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -20,7 +20,7 @@ use fvm_shared::econ::TokenAmount;
 use fvm_shared::message::Message;
 use fvm_shared::state::StateTreeVersion;
 use fvm_shared::version::NetworkVersion;
-use log::{info, trace};
+use log::{debug, info};
 use prettytable::{row, Table};
 use serde::{Deserialize as SerdeDeserialize, Serialize as SerdeSerialize};
 use std::collections::HashMap;
@@ -256,7 +256,7 @@ impl TestExecutor {
         params.extend(num_bytes);
         params.extend(call_bytes);
 
-        trace!(
+        debug!(
             "{} call params:  {}",
             method_name,
             hex::encode(params.clone())

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -256,6 +256,9 @@ impl TestExecutor {
         params.extend(num_bytes);
         params.extend(call_bytes);
 
+        // assert its well formatted cbor
+        assert!(serde_cbor::from_slice::<&[u8]>(&params).is_ok());
+
         debug!(
             "{} call params:  {}",
             method_name,

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -328,7 +328,7 @@ impl CallResult {
 /// Represents a Filecoin address
 #[derive(Debug)]
 pub struct FilAddress {
-    data: Vec<u8>,
+    pub data: Vec<u8>,
 }
 
 impl FilAddress {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -97,6 +97,19 @@ impl TestExecutor {
         })
     }
 
+    /// Fetches an account by index
+    pub fn get_account(&self, idx: usize) -> Result<Account, Box<dyn Error>> {
+        if idx >= self.accounts.len() {
+            return Err(ExecutorError::UninitializedState.into());
+        }
+        Ok(self.accounts[idx])
+    }
+
+    /// Fetches an account by index
+    pub fn current_sender(&self) -> Account {
+        self.sender
+    }
+
     /// Fetches balance for a specific actor id
     pub fn get_balance(&self, actor_id: u64) -> Result<TokenAmount, Box<dyn Error>> {
         Ok(self

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -36,7 +36,7 @@ pub struct CreateExternalParams(#[serde(with = "strict_bytes")] pub Vec<u8>);
 ///
 pub type GasResult = Vec<(String, u64)>;
 
-///
+/// calldata is encoding as a byte array of variable length with length encoded by (1, 2, 4, 8 bytes)
 const PARAMS_CBOR_HEADER: [&str; 4] = ["58", "59", "5a", "5b"];
 
 #[derive(thiserror::Error, Debug)]

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -105,7 +105,7 @@ impl TestExecutor {
         Ok(self.accounts[idx])
     }
 
-    /// Fetches an account by index
+    /// Fetches currently active account
     pub fn current_sender(&self) -> Account {
         self.accounts[self.sender]
     }

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -258,16 +258,16 @@ impl TestExecutor {
         params.extend(num_bytes);
         params.extend(call_bytes);
 
-        // assert its well formatted cbor
-        if !(serde_cbor::from_slice::<&[u8]>(&params).is_ok()) {
-            return Err(ExecutorError::BadParams.into());
-        }
-
-        debug!(
+        info!(
             "{} call params:  {}",
             method_name,
             hex::encode(params.clone())
         );
+
+        // assert its well formatted cbor
+        if !(serde_cbor::from_slice::<&[u8]>(&params).is_ok()) {
+            return Err(ExecutorError::BadParams.into());
+        }
 
         let params = RawBytes::new(params);
 

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -332,6 +332,10 @@ pub struct FilAddress {
 }
 
 impl FilAddress {
+    /// constructor
+    pub fn new(data: Vec<u8>) -> Self {
+        Self { data }
+    }
     /// converts to eth token
     pub fn to_eth_token(&self) -> Token {
         Token::Tuple(vec![Token::Bytes(self.data.clone())])

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -51,6 +51,8 @@ pub enum ExecutorError {
     UninitializedSequence,
     #[error("unnable to load actors")]
     BadActors,
+    #[error("incorrectly formatted params")]
+    BadParams,
 }
 
 ///
@@ -257,7 +259,9 @@ impl TestExecutor {
         params.extend(call_bytes);
 
         // assert its well formatted cbor
-        assert!(serde_cbor::from_slice::<&[u8]>(&params).is_ok());
+        if !(serde_cbor::from_slice::<&[u8]>(&params).is_ok()) {
+            return Err(ExecutorError::BadParams.into());
+        }
 
         debug!(
             "{} call params:  {}",

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -328,7 +328,7 @@ impl CallResult {
 /// Represents a Filecoin address
 #[derive(Debug)]
 pub struct FilAddress {
-    pub data: Vec<u8>,
+    data: Vec<u8>,
 }
 
 impl FilAddress {

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -107,7 +107,7 @@ impl TestExecutor {
 
     /// Fetches an account by index
     pub fn current_sender(&self) -> Account {
-        self.sender
+        self.accounts[self.sender]
     }
 
     /// Fetches balance for a specific actor id


### PR DESCRIPTION
- This fixes the CBOR headers for calldata to accomodate variable length **length bytes** (what a mouthful). 
- Adds more informative logging  
- Helper methods for retrieving account data on executor