### PR TITLE
fix: bundle path set by env variables

### DIFF
--- a/src/executor.rs
+++ b/src/executor.rs
@@ -398,7 +398,11 @@ impl Contract {
 pub fn setup_tester() -> Result<(Tester<MemoryBlockstore, DummyExterns>, Manifest), Box<dyn Error>>
 {
     let bs = MemoryBlockstore::default();
-    let actors = include_bytes!("../builtin-actors/output/builtin-actors-mainnet.car");
+    let actors = include_bytes!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/builtin-actors/output/builtin-actors-mainnet.car"
+    ));
+
     let bundle_root = bundle::import_bundle(&bs, &actors[..])?;
 
     let (manifest_version, manifest_data_cid): (u32, Cid) = match bs.get_cbor(&bundle_root)? {


### PR DESCRIPTION
- Actor `car` path currently set by relative variables not by `env` 